### PR TITLE
internal/http: Account sign up and log in

### DIFF
--- a/cmd/registryd/main.go
+++ b/cmd/registryd/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"log"
 	"os"
+	"path/filepath"
 
+	"github.com/asdine/storm"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
@@ -37,7 +39,7 @@ func main() {
 
 	dbPath := filepath.Join(viper.GetString("storage.root"), "registry.db")
 
-	s, err := storm.Open(dbPath)
+	st, err := storm.Open(dbPath)
 	if err != nil {
 		log.Panic(err)
 	}
@@ -47,7 +49,7 @@ func main() {
 		log.Panic(err)
 	}
 
-	mg, err := mechgreg.New(mechgreg.ResourceBundle{s})
+	mg, err := mechgreg.New(mechgreg.ResourceBundle{st})
 	if err != nil {
 		log.Panic(err)
 	}

--- a/internal/http/accounts.go
+++ b/internal/http/accounts.go
@@ -1,0 +1,96 @@
+package http
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/BESTRobotics/registry/internal/models"
+	"github.com/BESTRobotics/registry/internal/token"
+)
+
+func (s *Server) registerLocalUser(c *gin.Context) {
+	// Decode the user struct and add the authenticating
+	// information to an authdata which needs to be seperated from
+	// the user meta.  After that send a mail with the magic link
+	// to activate the account.
+	var regRequest struct {
+		U        models.User
+		Password string
+	}
+	if err := c.ShouldBindJSON(&regRequest); err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		log.Println(err)
+		return
+	}
+
+	// If this returns nil then the user already exists and we
+	// abort.
+	if _, err := s.mg.UsernameExists(regRequest.U.Username); err == nil {
+		c.Status(http.StatusConflict)
+		return
+	}
+
+	// User doesn't exist, time to create the user:
+	_, err := s.mg.NewUser(regRequest.U)
+	if err != nil {
+		s.handleError(c, err)
+		return
+	}
+
+	// And now we set the authdata (password in this case).
+	if err := s.mg.SetUserPassword(regRequest.U.Username, regRequest.Password); err != nil {
+		s.handleError(c, err)
+		return
+	}
+
+	// TODO Message the user via Email that they need to use the
+	// activation link.
+	c.Status(http.StatusCreated)
+}
+
+// loginLocaluser logs in the user using the authentication
+// information provided and redirects the browser into the app with a
+// token unless a boomerang target was specified in the query string.
+func (s *Server) loginLocalUser(c *gin.Context) {
+	target := "/app/login#t=%s"
+
+	var ld struct {
+		Username string
+		Password string
+	}
+	if err := c.ShouldBindJSON(&ld); err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		log.Println(err)
+		return
+	}
+
+	// Figure out who this user is.
+	user, err := s.mg.UsernameExists(ld.Username)
+	if err != nil {
+		s.handleError(c, err)
+		return
+	}
+
+	// Check the user password, if its successful then generate a
+	// token and hand it off.
+	err = s.mg.CheckUserPassword(ld.Username, ld.Password)
+	if err != nil {
+		s.handleError(c, err)
+		return
+	}
+
+	// Get the token
+	log.Println(user)
+	tkn, err := s.generateToken(user.ID, token.GetConfig())
+	if err != nil {
+		s.handleError(c, err)
+		return
+	}
+
+	// Put the token into the URL
+	target = fmt.Sprintf(target, tkn)
+	c.Redirect(http.StatusMovedPermanently, target)
+}

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -37,6 +37,9 @@ func New(mg MechGreg, tkn *token.RSATokenService) (*Server, error) {
 
 	v1 := s.g.Group("v1/")
 	{
+		v1.POST("/account/register/local", s.registerLocalUser)
+		v1.POST("/account/login/local", s.loginLocalUser)
+
 		v1.GET("/users", s.getUsers)
 		v1.POST("/users", s.newUser)
 		v1.GET("/users/:uid", s.getUser)
@@ -135,6 +138,13 @@ func (s *Server) handleError(c *gin.Context, err error) {
 		}
 		c.AbortWithStatusJSON(ierr.Code(), err)
 		return
+	case *mechgreg.AuthError:
+		aerr, ok := err.(*mechgreg.AuthError)
+		if !ok {
+			break
+		}
+		c.AbortWithStatusJSON(aerr.Code(), err)
+		return
 	case AuthError:
 		aerr, ok := err.(AuthError)
 		if !ok {
@@ -143,6 +153,7 @@ func (s *Server) handleError(c *gin.Context, err error) {
 		c.AbortWithStatusJSON(aerr.Code(), err)
 		return
 	}
+	log.Println(err)
 	c.AbortWithError(http.StatusInternalServerError, err)
 	return
 }

--- a/internal/http/type.go
+++ b/internal/http/type.go
@@ -24,6 +24,9 @@ type MechGreg interface {
 	GetUser(int) (models.User, error)
 	ModUser(models.User) error
 	GetUserPage(int, int) ([]models.User, error)
+	UsernameExists(string) (models.User, error)
+	SetUserPassword(string, string) error
+	CheckUserPassword(string, string) error
 
 	NewSeason(models.Season) (int, error)
 	GetSeason(int) (models.Season, error)

--- a/internal/mechgreg/errors.go
+++ b/internal/mechgreg/errors.go
@@ -53,3 +53,30 @@ func (e *InternalError) Error() string {
 func (e *InternalError) Code() int {
 	return e.httpCode
 }
+
+// AuthError is returned when authentication information on login is
+// incorrect.
+type AuthError struct {
+	Message string
+	Cause   error
+
+	httpCode int
+}
+
+// NewAuthError returns a populated AuthError.
+func NewAuthError(s string, err error, c int) error {
+	return &AuthError{
+		Message:  s,
+		Cause:    err,
+		httpCode: c,
+	}
+}
+
+func (e *AuthError) Error() string {
+	return e.Message
+}
+
+// Code returns the http status code represented by this error.
+func (e *AuthError) Code() int {
+	return e.httpCode
+}

--- a/internal/mechgreg/mg.go
+++ b/internal/mechgreg/mg.go
@@ -1,5 +1,11 @@
 package mechgreg
 
+import (
+	"log"
+
+	"github.com/BESTRobotics/registry/internal/models"
+)
+
 // New returns a new mechanical greg. The mechanical greg abstraction
 // is a convenient way to refer to the behaviors and things the server
 // needs to do.  Kind of like a mechanical turk, the mechanical greg
@@ -9,5 +15,25 @@ func New(rb ResourceBundle) (*MechanicalGreg, error) {
 	mg := MechanicalGreg{
 		s: rb.StormDB,
 	}
+
+	if err := mg.s.ReIndex(&models.User{}); err != nil {
+		log.Println("Error during indexing", err)
+	}
+	if err := mg.s.ReIndex(&models.AuthData{}); err != nil {
+		log.Println("Error during indexing", err)
+	}
+	if err := mg.s.ReIndex(&models.Hub{}); err != nil {
+		log.Println("Error during indexing", err)
+	}
+	if err := mg.s.ReIndex(&models.Team{}); err != nil {
+		log.Println("Error during indexing", err)
+	}
+	if err := mg.s.ReIndex(&models.Season{}); err != nil {
+		log.Println("Error during indexing", err)
+	}
+	if err := mg.s.ReIndex(&models.School{}); err != nil {
+		log.Println("Error during indexing", err)
+	}
+
 	return &mg, nil
 }

--- a/internal/models/authdata.go
+++ b/internal/models/authdata.go
@@ -1,0 +1,39 @@
+package models
+
+import (
+	"fmt"
+	"strings"
+)
+
+// AuthData is what's used to actually log in users to the system.
+type AuthData struct {
+	// Though not directly used, the record still needs an index.
+	ID int `storm:"id,increment"`
+
+	// Username points to the user that this belongs to.  Its just
+	// a pointer here, so just a string.
+	Username string
+
+	// Provider here specifies what fields need to be filled in
+	// for this authenticator.
+	Provider string
+
+	// Password is the hash of a users's password.
+	Password string
+}
+
+// Validate figures out if the data in the structure is valid for the
+// provider that is declared.  It returns an error if it is not.
+func (a AuthData) Validate() error {
+	if a.Username == "" {
+		return fmt.Errorf("username must be set")
+	}
+
+	switch strings.ToUpper(a.Provider) {
+	case "PASSWORD":
+		if a.Password == "" {
+			return fmt.Errorf("the password hash must be set")
+		}
+	}
+	return nil
+}

--- a/web/doc.go
+++ b/web/doc.go
@@ -2,5 +2,6 @@
 // registry server to provide a nice UI for end users.  This is a
 // react app which has to be built for statik inclusion.
 package web
+
 //go:generate yarn run build
 //go:generate fileb0x fileb0x.yml


### PR DESCRIPTION
This includes the base components to be able to create local accounts and log them in.   It also implements a "shim IdP" by being able to plug in different targets and token configurations.  This might be useful for feeding identity information to external systems.