### PR TITLE
Add a mechanism for token renewal.

### DIFF
--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -41,6 +41,7 @@ func New(mg MechGreg, tkn *token.RSATokenService, po mail.Mailer) (*Server, erro
 
 	s.ws.POST("v1/account/register/local", s.registerLocalUser)
 	s.ws.POST("v1/account/login/local", s.loginLocalUser)
+	s.ws.POST("v1/account/token/renew", s.renewToken)
 
 	s.ws.GET("v1/users", s.getUsers)
 	s.ws.POST("v1/users", s.newUser)

--- a/internal/http/token.go
+++ b/internal/http/token.go
@@ -117,3 +117,20 @@ func (s *Server) generateToken(id int, cfg token.Config) (string, error) {
 	}
 	return s.tkn.Generate(claims, cfg)
 }
+
+func (s *Server) renewToken(c echo.Context) error {
+	// TODO: This extends the lifetime of the token, but to do
+	// otherwise means we'll need to fix things in the underlying
+	// token system.
+	claims := extractClaims(c)
+	if err := isAuthenticated(claims); err != nil {
+		return s.handleError(c, err)
+	}
+
+	tkn, err := s.generateToken(claims.User.ID, token.GetConfig())
+	if err != nil {
+		return s.handleError(c, err)
+	}
+
+	return c.JSON(http.StatusOK, tkn)
+}


### PR DESCRIPTION
This commit adds a mechanism to renew the token provided to the
client.  This allows the token to re-encode new things that might have
just been created.

Resolves #26.
Component of #25.